### PR TITLE
Make join links public

### DIFF
--- a/_courses/200504-lammps.md
+++ b/_courses/200504-lammps.md
@@ -72,3 +72,39 @@ We will provide accounts on one of our HPC services, for all attendees who regis
 
 - Exercises, discussion and questions.
 		
+
+
+
+<section id="service">
+    <div class="row ">	
+
+      <div class="col-xs-6 col-sm-4">
+        <a class="ar2_linkbox ar2_linkbox-green" 
+          href="https://eu.bbcollab.com/guest/4cf5fc2f33d744428382ac7ddf9617de ">
+          <strong>Join Session 1 : 4th May</strong><br/>
+          Join this online session in your browser.
+        </a>
+
+      </div>	
+
+
+      <div class="col-xs-6 col-sm-4">
+        <a class="ar2_linkbox ar2_linkbox-teal" 
+          href="https://eu.bbcollab.com/guest/38454afc61534fada5bc43bee9c7e592 ">
+          <strong>Join Session 2 : 11th May</strong><br/>
+          Join this online session in your browser.
+        </a>
+
+      </div>
+
+      <div class="col-xs-6 col-sm-4">
+        <a class="ar2_linkbox ar2_linkbox-green" 
+          href="https://eu.bbcollab.com/guest/9cff3091a8a74a33b30cad3b3974b742  ">
+          <strong>Join Session 3 : 18th May</strong><br/>
+          Join this online session in your browser.
+        </a>
+
+      </div>
+
+											
+    </div>


### PR DESCRIPTION
As agreed at training meeting, links will be public, but delegates must register to be invited to sign up for y14 account.