### PR TITLE
Reformat link to LAMMPS Materials

### DIFF
--- a/_courses/200504-lammps.md
+++ b/_courses/200504-lammps.md
@@ -74,9 +74,23 @@ We will provide accounts on one of our HPC services, for all attendees who regis
 		
 ## Course materials
 
-The course materials are available here: [https://git.ecdf.ed.ac.uk/jsindt/archer2-lammps-course](https://git.ecdf.ed.ac.uk/jsindt/archer2-lammps-course)
 
-Unless otherwise indicated all material is Copyright &copy; EPCC, The University of Edinburgh, and is only made available for private study.
+
+<section id="service">
+    <div class="row ">	
+      <div class="col-xs-6 col-sm-4">
+        <a class="ar2_linkbox ar2_linkbox-teal" 
+          href="https://git.ecdf.ed.ac.uk/jsindt/archer2-lammps-course ">
+          <strong>Course materials</strong><br/>
+          Unless otherwise indicated all material is Copyright &copy; EPCC, The University of Edinburgh, and is only made available for private study.
+        </a>
+
+      </div>
+		
+		</div>
+					
+
+<h2>Join sessions		</h2>		
 
 
 <section id="service">


### PR DESCRIPTION
Reformat to use the link box.
Remove link text to meet accessibility guidelines.