### PR TITLE
Move to brief description and fix trainers in body issue

### DIFF
--- a/_courses/200713-containers.md
+++ b/_courses/200713-containers.md
@@ -14,7 +14,6 @@ location_url:
 prace_course: true
 ---
 
-
 This course aims to introduce the use of containers with the goal of using them to effect reproducible computational environments. Such environments are useful for ensuring reproducible research outputs and for simplifying the setup of complex software dependencies across different systems. The course will mostly be based around the use of Docker containers but the material will be of use for whatever container technology you plan to, or end up, using. We will also briefly introduce the Singularity container environment which is compatible with Docker and designed for use on multi-user systems (such as HPC resources). On completion of this course attendees should:
 
 * Understand what containers are and what they are used for
@@ -23,8 +22,6 @@ This course aims to introduce the use of containers with the goal of using them 
 * Understand the differences between Docker and Singularity containers and why Singularity is more suitable for multi-user systems (e.g. HPC)
 * Understand how to manage and create Singularity containers
 * Appreciate how containers can be used to enable and improve reproducibility in research
-
-**Trainers:** Andy Turner (EPCC) and [Jeremy Cohen]( https://www.imperial.ac.uk/people/jeremy.cohen) (Imperial College)
 
 **Location:** This course will be run primarily as a remote attendance course but depending on how the current situation evolves over the coming weeks, there may also be an opportunity to attend the training in person at Imperial College London's South Kensington Campus. We will advise whether in-person attendance is possible in mid June.
 

--- a/training/courses/index.md
+++ b/training/courses/index.md
@@ -102,21 +102,7 @@ This course will cover the ARCHER2 application development environment, core par
 
 *Course length: 2 days. Course level: introductory.*
 
-This course aims to introduce the use of Docker containers with the goal of using them to effect reproducible computational environments. Such environments are useful for ensuring reproducible research outputs and for simplifying the setup of complex software dependencies across different systems. We will also briefly introduce the Singularity container environment which is compatible with Docker and designed for use on multi-user systems (such as HPC resources).
-
-*Target Audience:*
-
-- This course is aimed at researchers who have no (or very little) previous experience of using containers. 
-
-*Prerequisites:*
-
-- You should have basic familiarity with using a command shell, and the lesson text will at times request that you "open a shell window”, with an assumption that you know what this means. 
-    + Under Linux or macOS it is assumed that you will access a bash shell (usually the default), using your *Terminal* application.
-    + Under Windows, *Powershell* and *Git Bash* should allow you to use the Unix instructions. We will also try to give command variants for Windows `cmd.exe`
-
-*Requirements:*
-
-- Participants must bring a laptop with a Mac, Linux, or Windows operating system (not a tablet, Chromebook, etc.) that they have administrative privileges on.
+This course aims to introduce the use of containers with the goal of using them to effect reproducible computational environments. Such environments are useful for ensuring reproducible research outputs and for simplifying the setup of complex software dependencies across different systems. We will primarily use Docker to illustrate the use of containers but will also briefly introduce Singularity which is designed for use on multi-user systems (such as HPC resources). This course is aimed at researchers who have no (or very little) previous experience of using containers. Attendees are expected to have basic familiarity with using a command line interface such as bash or Powershell.
 
 <p><a name="intermediate">&nbsp;</a></p>
 ### Intermediate (level 2) courses


### PR DESCRIPTION
Moved back to a brief description of the containers course and removed trainers details from body of containers course.