### PR TITLE
Adds mechanism to add service alerts as collection

### DIFF
--- a/_alerts/2021-11-01_4cab-nodes-down.md
+++ b/_alerts/2021-11-01_4cab-nodes-down.md
@@ -1,0 +1,9 @@
+---
+status: Resolved
+type: Issue
+start_date: 2021-11-01 09:30:00
+end_date: 2021-11-01 11:30:00
+scope: 4-cabinet service Compute nodes
+impact: There were 285 nodes down so queue times may be longer
+reason: A user job hit a known bug and brought down 256 nodes
+---

--- a/_alerts/2021-11-01_nodes-down.md
+++ b/_alerts/2021-11-01_nodes-down.md
@@ -1,0 +1,9 @@
+---
+status: Resolved
+type: Issue
+start_date: 2021-11-01 09:30:00
+end_date: 2021-11-01 11:30:00
+scope: Compute nodes
+impact: There are 285 nodes down so queue times may be longer
+reason: A user job hit a known bug and brought down 256 compute nodes
+---

--- a/_alerts/2021-11-03_network-incident.md
+++ b/_alerts/2021-11-03_network-incident.md
@@ -1,0 +1,9 @@
+---
+status: Resolved
+type: Issue
+start_date: 2021-11-03 14:45:00
+end_date: 2021-11-03 14:45:00
+scope: Login access
+impact: The login-4c.archer2.ac.uk address is unreachable so logins via this address will fail, users can use the address 193.62.216.1 instead
+reason: A short network outage at the University of Edinburgh caused issues with resolving the ARCHER2 login host names
+---

--- a/_alerts/2021-11-05_power-incident.md
+++ b/_alerts/2021-11-05_power-incident.md
@@ -1,0 +1,9 @@
+---
+status: Resolved
+type: Issue
+start_date: 2021-11-05 08:00:00
+end_date: 2021-11-05 11:30:00
+scope: Compute nodes
+impact: A large number of compute nodes were unavailable for jobs
+reason: A power incident in the Edinburgh area caused a number of cabinets to lose power
+---

--- a/_alerts/2021-11-14_monitoring-failure.md
+++ b/_alerts/2021-11-14_monitoring-failure.md
@@ -1,0 +1,9 @@
+---
+status: Resolved
+type: Issue
+start_date: 2021-11-14 08:00:00
+end_date: 2021-11-15 09:40:00
+scope: Service monitoring
+impact: Load chart on website missing some historical data
+reason: A login node issue caused data to not be collected
+---

--- a/_alerts/2021-12-16_spine-failure.md
+++ b/_alerts/2021-12-16_spine-failure.md
@@ -1,0 +1,9 @@
+---
+status: Resolved
+type: Issue
+start_date: 2021-12-16 04:05:00
+end_date: 2021-12-16 09:41:00
+scope: Slurm scheduler unavailable, outgoing connections failed
+impact: Slurm commands did not work, outgoing connections did not work, running jobs continued without issue
+reason: Spine switch became unresponsive
+---

--- a/_alerts/2021-12-20_4cab-slow-slurm.md
+++ b/_alerts/2021-12-20_4cab-slow-slurm.md
@@ -1,0 +1,9 @@
+---
+status: Resolved
+type: Issue
+start_date: 2021-12-20 13:00:00
+end_date: 2021-12-20 14:12:00
+scope: 4-cabinet service Slurm scheduler
+impact: Response from Slurm scheduler was degraded, running jobs unaffected
+reason: Slurm scheduler was experiencing issues
+---

--- a/_alerts/2021-12-31_nodes-down.md
+++ b/_alerts/2021-12-31_nodes-down.md
@@ -1,0 +1,9 @@
+---
+status: Ongoing
+type: Issue
+start_date: 2021-12-31 10:00:00
+end_date: 
+scope: Compute nodes
+impact: Running jobs on down nodes failed, reduced number of compute nodes available
+reason: A number of compute nodes are unavailable due to hardware issue
+---

--- a/_alerts/2022-01-09_dns-issue.md
+++ b/_alerts/2022-01-09_dns-issue.md
@@ -1,0 +1,9 @@
+---
+status: Resolved
+type: Issue
+start_date: 2022-01-09T10:00:00
+end_date: 2022-01-10T10:30:00
+scope: Login and Data Analysis nodes, SAFE
+impact: Outgoing network access from ARCHER2 systems to external sites was not working. SAFE response was slow or degraded.
+reason: DNS issue at datacentre
+---

--- a/_alerts/2022-01-10_4cab-shutdown.md
+++ b/_alerts/2022-01-10_4cab-shutdown.md
@@ -1,0 +1,9 @@
+---
+status: Resolved
+type: Notice
+start_date: 2022-01-10T12:00:00
+end_date: 2022-01-10T12:00:00
+scope: 4-cabinet system
+impact: Users can no longer use the ARCHER2 4-cabinet system or access /work data on the 4-cabinet system
+reason: The ARCHER2 4-cabinet system was removed from service as planned
+---

--- a/_config.yml
+++ b/_config.yml
@@ -39,6 +39,9 @@ descriptions:
 collections:
   courses:
     output: true
-    permalink: /training/courses/:path/    
+    permalink: /training/courses/:path/
+  alerts:
+    output: false
+    
 
 future: true

--- a/support-access/history/alerts.md
+++ b/support-access/history/alerts.md
@@ -1,22 +1,87 @@
 ---
 layout: section
-title: Service Alerts
-summary: Log of previous ARCHER2 Service Alerts
+title: Resolved Service Alerts
+summary: Log of resolved ARCHER2 Service Alerts
 banner: web_banners_03.jpg
 ---
 
-- [Q4 2021](#service-alerts-quarter-4-2021---1st-october---31-december-2021)
+{% assign resolved_alerts = site.alerts | where_exp: "alert", "alert.status == 'Resolved'" %}
+{% for alert in resolved_alerts reversed %}
 
+    {% capture curryear %}
+    {{ alert.end_date | date: "%Y" }}
+    {% endcapture %}
 
+    {% if forloop.first %}
+       {% assign prevyear = curryear %}
+<h2>{{ curryear }}</h2>
+<div class="table-responsive">
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>Status</th>
+        <th>Type</th>
+        <th>Start</th>
+        <th>End</th>
+        <th>Scope</th>
+        <th>User Impact</th>
+        <th>Reason</th>
+      </tr>
+    </thead>
+    <tbody>
+    {% endif %}
 
+    {% if curryear != prevyear %}
+    </tbody>
+  </table>
+</div>
+<h2>{{ curryear }}</h2>
+<div class="table-responsive">
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>Status</th>
+        <th>Type</th>
+        <th>Start</th>
+        <th>End</th>
+        <th>Scope</th>
+        <th>User Impact</th>
+        <th>Reason</th>
+      </tr>
+    </thead>
+    <tbody>      
+    {% endif %}
 
-##  Service Alerts Quarter 4 2021 - 1st October - 31 December 2021
+      <tr>
+      <td>
+        {{ alert.status }}
+      </td>
+      <td>
+        {{ alert.type }}
+      </td>
+      <td>
+        {{ alert.start_date }}
+      </td>
+      <td>
+        {{ alert.end_date }}
+      </td>
+      <td>
+        {{ alert.scope }}
+      </td>
+      <td>
+        {{ alert.impact }}
+      </td>
+      <td>
+        {{ alert.reason }}
+      </td>
+      </tr>
 
-| Status | Type | Start | End | System | User Impact | Reason |
-| ---    | ---  | ---   | --- | ---    | ---         | ---    |
-| Resolved | Issue | 2021-12-20 13:00 | 2021-12-20 14:12 | ARCHER2 4-cabinet: Slurm  | Slurm slowdown - slurm rebooted at 14:00. Running jobs continued without issue. | Slurm slowdown |
-| Resolved | Issue | 2021-12-16 0405 | 2021-12-16 0941 | ARCHER2 full system: Slurm and outgoing SSH | Slurm commands did not work. Outgoing SSH connections did not work. Running jobs continued without issue. | The ARCHER2 spine switch network became unresponsive. |
-| Resolved | Issue | 2021-11-14 0800 | 2021-11-15 0940 | ARCHER2 4-cabinet: status monitoring | The load chart on the website is missing some historical data. | An issue on one of the login nodes caused usage data to not be collected. |
-| Resolved | Issue | 2021-11-05 0800 | 2021-11-05 1130 | ARCHER2 4-cabinet: compute nodes | A large number of compute nodes were unavailable for jobs.  | A power incident in the Edinburgh area caused a number of cabinets to lose power. |  
-| Resolved | Issue | 2021-11-03 1445 | 2021-11-03 1445 | ARCHER2 4-cabinet | The login-4c.archer2.ac.uk address is unreachable so logins via this address will fail. Users can use the address 193.62.216.1 instead.  | A short network outage at the University of Edinburgh caused issues with resolving the ARCHER2 login host names. |  
-| Resolved | Issue | 2021-11-01 0930 | 2021-11-01 1130 | ARCHER2 4-cabinet | There were 285 nodes down so queue times may be longer. The nodes have now been returned to service.  | A user job hit a known bug and brought down 256 nodes. The bug has been fixed in Shasta 1.5 which will be available on the full service. | 
+    {% if forloop.last %}
+    </tbody>
+  </table>
+</div>
+    {% endif %}
+
+    {% assign prevyear = curryear %}
+
+{% endfor %}

--- a/support-access/status.md
+++ b/support-access/status.md
@@ -58,29 +58,126 @@ is used to support small, short jobs with fast turnaround time.
 
 The ARCHER2 documentation also covers some [Known Issues](https://docs.archer2.ac.uk/known-issues/) which users may encounter when using the system.
 
-| Status | Type | Start | End | System | User Impact | Reason |
-| ---    | ---  | ---   | --- | ---    | ---         | ---    |
-| Ongoing | Issue | 2021-12-31 10:00 |  | ARCHER2 Full System: Downed nodes  | A number of nodes downed due to hardware issue, running jobs on downed nodes failed  | Hardware issue |
 
-### Recent Service Alerts
+{% assign current_alerts = site.alerts | where_exp: "alert", "alert.status == 'Ongoing'" %}
+{% for alert in current_alerts reversed %}
+    {% if forloop.first == true %}
+<div class="table-responsive">
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>Status</th>
+        <th>Type</th>
+        <th>Start</th>
+        <th>End</th>
+        <th>Scope</th>
+        <th>User Impact</th>
+        <th>Reason</th>
+      </tr>
+    </thead>
+    <tbody>
+    {% endif %}
+      <tr>
+      <td>
+        {{ alert.status }}
+      </td>
+      <td>
+        {{ alert.type }}
+      </td>
+      <td>
+        {{ alert.start_date }}
+      </td>
+      <td>
+        {{ alert.end_date }}
+      </td>
+      <td>
+        {{ alert.scope }}
+      </td>
+      <td>
+        {{ alert.impact }}
+      </td>
+      <td>
+        {{ alert.reason }}
+      </td>
+     </tr>
+    {% if forloop.last == true %}
+    </tbody>
+  </table>
+</div>
+    {% endif %}
+{% else %}
+<p>No current service alerts</p>
+{% endfor %}
 
-| Status | Type | Start | End | System | User Impact | Reason |
-| ---    | ---  | ---   | --- | ---    | ---         | ---    |
-| Resolved | Notice | 2022-01-10 12:00 | 2022-01-10 12:00 | ARCHER2 4-cabinet system  | Users can no longer use the 4-cabinet ARCHER2 system | The ARCHER2 4-cabinet system was removed from service as planned |
-| Resolved | Issue | 2022-01-09 10:00 | 2022-01-10 10:30 | ARCHER2 full system, ARCHER2 4-cabinet system, SAFE  | Outgoing network access from ARCHER2 systems to external sites was not working. SAFE response was slow or degraded.  | DNS issue at datacentre |
+### Pervious Service Alerts
 
-### Service Alerts for previous periods
+This table lists resolved service alerts from the past month. 
+[A full list of historical resolved service alerts is available](history/alerts).
 
-[Previous service alerts](history/alerts)
+{% assign resolved_alerts = site.alerts | where_exp: "alert", "alert.status == 'Resolved'" %}
+{% assign date_now = "now" | date: "%s" %}
+{% assign date_thresh = date_now | minus: 2592000 | date: "%s" %}
+{% assign count = 0 %}
+{% for alert in resolved_alerts reversed %}
+    {% assign ed = alert.end_date | date: "%s" %}
+    {% if ed > date_thresh %}
+        {% if count == 0 %}
+<div class="table-responsive">
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>Status</th>
+        <th>Type</th>
+        <th>Start</th>
+        <th>End</th>
+        <th>Scope</th>
+        <th>User Impact</th>
+        <th>Reason</th>
+      </tr>
+    </thead>
+    <tbody>
+        {% endif %}
+      <tr>
+      <td>
+        {{ alert.status }}
+      </td>
+      <td>
+        {{ alert.type }}
+      </td>
+      <td>
+        {{ alert.start_date }}
+      </td>
+      <td>
+        {{ alert.end_date }}
+      </td>
+      <td>
+        {{ alert.scope }}
+      </td>
+      <td>
+        {{ alert.impact }}
+      </td>
+      <td>
+        {{ alert.reason }}
+      </td>
+      </tr>
+        {% assign count = count | plus: 1 %}
+    {% endif %}
+{% endfor %}
+{% if count > 0 %}
+    </tbody>
+  </table>
+</div>
+{% else %}
+<p>No recent service alerts</p>
+{% endif %}
 
 ## Maintenance Sessions 
 
-###Quarter 1 2022 (1st January - 31st March 2022)
+### Quarter 1 2022 (1st January - 31st March 2022)
 
-| Status | Type | Start | End | System | User Impact | Reason |
+| Status | Type | Start | End | Scope | User Impact | Reason |
 | ---    | ---  | ---   | --- | ---    | ---         | ---    |
-| Planned: RFC0093 | Partial : Login and Serial Nodes| 2022-01-26 10:00|2022-01-26 12:00 | ARCHER2 Login and Serial Nodes | Users will be unable to connect to ARCHER2 and no jobs will run on the serial nodes.  | To attach the ARCHER2 /home filesystem to a new network at the Advanced Computing Facility   |
-
+| Planned: RFC0093 | Partial : Login and Serial Nodes | 2022-01-26 10:00|2022-01-26 12:00 | ARCHER2 Login and Serial Nodes | Users will be unable to connect to ARCHER2 and no jobs will run on the serial nodes.  | To attach the ARCHER2 /home filesystem to a new network at the Advanced Computing Facility   |
 
 ### Maintenance Logs for previous periods
 


### PR DESCRIPTION
Updates structure so that service alerts are added as a collection to allow automatic construction of tables on status pages and automatic generation and catagorisation of historical service alerts.

To create a new service alert:

1. Create a file in the `_alerts/` subdirectory with a name like `YYYY-MM-DD_alert-reason.md`
2. Add the service alert details to the file *frontmatter*, for example:
    ```
    ---
    status: Ongoing
    type: Issue
    start_date: 2021-12-31 10:00:00
    end_date: 
    scope: Compute nodes
    impact: Running jobs on down nodes failed, reduced number of compute nodes available
    reason: A number of compute nodes are unavailable due to hardware issue
    ---
    ```
3. Save and commit to the repo. The alert will automatically be added to the correct place

To mark a service alert as resolved, edit the file in `_alerts/`, change the status to `Resolved` and add the end date.

Notes:
* The status **must** be `Ongoing` or `Resolved` as these names are used to filter the alert into the correct places.
* Day/time formats for `start_time` and `end_time` must be in the format `YYYY-MM-DD hh:mm:ss`