### PR TITLE
Fix broken alert message

### DIFF
--- a/_alerts/2022-05-09_slurm_upgrade.md
+++ b/_alerts/2022-05-09_slurm_upgrade.md
@@ -4,8 +4,7 @@ type: Issue
 start_date: 2022-05-09 09:00
 end_date: 2022-05-16 12:00
 scope: The Slurm batch scheduler will be upgraded. In total the work will take around a week but user impact is expected to be limited to 6 hours when users will not be able to submit new jobs and new jobs will not start
-impact: Wednesday 11th May 1000 – 1400 and Monday 16th May 1000 – 1200
-Running jobs will not be impacted but users will not be able to submit new jobs and new jobs will not start.    
+impact: Wednesday 11th May 1000 – 1400 and Monday 16th May 1000 – 1200 <br>Running jobs will not be impacted but users will not be able to submit new jobs and new jobs will not start.    
 reason: Updating the Slurm software. 
 ---
 


### PR DESCRIPTION
Impact was split over two lines resulting in site build error.