### PR TITLE
Fix hover name of Twitter and GitHub icons

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -7,8 +7,8 @@
 				Website Design by <a href="http://helenmcfeely.blogspot.com/">Helen McFeely</a>.  <a href="{{ site.baseurl }}/about/credits.html">Image credits</a>.<br/>
         Template Copyright &copy; Design &amp; Developed by <a href="https://www.themefisher.com">Themefisher</a>. All rights reserved.</p>
         <a href="mailto:support@archer2.ac.uk"><ion-icon name="mail"></ion-icon></a>	
-        <a href="https://twitter.com/archer2_hpc"><ion-icon name="logo-twitter"></ion-icon></a>
-        <a href="https://www.github.com/archer2-hpc"><ion-icon name="logo-octocat"></ion-icon></a>
+        <a href="https://twitter.com/archer2_hpc"><ion-icon name="twitter"></ion-icon></a>
+        <a href="https://www.github.com/archer2-hpc"><ion-icon name="octocat"></ion-icon></a>
         </div>
       </div>
       <div class="col-xs-12 col-sm-12 col-md-12 col-lg-6">

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -7,8 +7,8 @@
 				Website Design by <a href="http://helenmcfeely.blogspot.com/">Helen McFeely</a>.  <a href="{{ site.baseurl }}/about/credits.html">Image credits</a>.<br/>
         Template Copyright &copy; Design &amp; Developed by <a href="https://www.themefisher.com">Themefisher</a>. All rights reserved.</p>
         <a href="mailto:support@archer2.ac.uk"><ion-icon name="mail"></ion-icon></a>	
-        <a href="https://twitter.com/archer2_hpc"><ion-icon name="twitter"></ion-icon></a>
-        <a href="https://www.github.com/archer2-hpc"><ion-icon name="octocat"></ion-icon></a>
+        <a href="https://twitter.com/archer2_hpc"><ion-icon name="logo-twitter" title="Twitter"></ion-icon></a>
+        <a href="https://www.github.com/archer2-hpc"><ion-icon name="logo-octocat" title="GitHub"></ion-icon></a>
         </div>
       </div>
       <div class="col-xs-12 col-sm-12 col-md-12 col-lg-6">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,6 +19,7 @@
 
     {% include footer.html %}
     
-      <script src="https://unpkg.com/ionicons@5.2.3/dist/ionicons.js"></script>
+      <script type="module" src="https://unpkg.com/ionicons@7.1.0/dist/ionicons/ionicons.esm.js"></script>
+      <script nomodule src="https://unpkg.com/ionicons@7.1.0/dist/ionicons/ionicons.js"></script>
     </body>
 </html>


### PR DESCRIPTION
The name of the Twitter and GitHub link in the footer are set the to "logo" which is odd to me.

Before:
![image](https://github.com/ARCHER2-HPC/archer2-website/assets/94064167/384c19ae-38ac-4372-aa63-0643203d0a83)

After:
![image](https://github.com/ARCHER2-HPC/archer2-website/assets/94064167/72ca1460-63a6-4883-b5d6-e2de378f702a)
